### PR TITLE
Fix testRecursive2 for UnitTest-1.0.2

### DIFF
--- a/tests/file_find_recursive_test.php
+++ b/tests/file_find_recursive_test.php
@@ -93,7 +93,7 @@ class ezcBaseFileFindRecursiveTest extends ezcTestCase
         );
 
         self::assertEquals( $expected, ezcBaseFile::findRecursive( "vendor/zetacomponents/unit-test", array( '@^vendor/zetacomponents/unit-test/@' ), array( '@/docs/@', '@\.git@', '@\.swp$@' ), $stats ) );
-        self::assertEquals( array( 'size' => 191012, 'count' => 11 ), $stats );
+        self::assertEquals( array( 'size' => 191166, 'count' => 11 ), $stats );
     }
 
     public function testRecursive3()


### PR DESCRIPTION
Hi there,
I noticed an error on the test suite on the last version of Base (1.9) with latest UnitTest (1.0.2),
since UnitTest is not moving for a while (last release on Oct 10, 2014), I fixed the expected size problem, and now the test suite run without error
```
$ phpunit
PHPUnit 5.7.3 by Sebastian Bergmann and contributors.

.................................................S.............  63 / 125 ( 50%)
.......SSSSSSSSSSSSSSSSS.............................SSSSSSS..  125 / 125 (100%)

Time: 355 ms, Memory: 15.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 125, Assertions: 155, Skipped: 25.
```

I hope it will be fine !