### PR TITLE
object is a reserved keywork in PHP 7.2

### DIFF
--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -424,8 +424,8 @@ class ezcBaseTest extends ezcTestCase
     public function testNoPrefixAutoload()
     {
         ezcBase::addClassRepository( __DIR__ . '/test_repository', __DIR__ . '/test_repository/autoload_files' );
-        ezc_autoload( 'Object' );
-        if ( !class_exists( 'Object' ) )
+        ezc_autoload( 'Objet' );
+        if ( !class_exists( 'Objet' ) )
         {
             $this->fail( "Autoload does not handle classes with no prefix" );
         }

--- a/tests/test_repository/autoload_files/object_autoload.php
+++ b/tests/test_repository/autoload_files/object_autoload.php
@@ -1,5 +1,0 @@
-<?php
-return array(
-	'Object' => 'object/object.php',
-);
-?>

--- a/tests/test_repository/autoload_files/objet_autoload.php
+++ b/tests/test_repository/autoload_files/objet_autoload.php
@@ -1,0 +1,5 @@
+<?php
+return array(
+	'Objet' => 'object/object.php',
+);
+?>

--- a/tests/test_repository/object/object.php
+++ b/tests/test_repository/object/object.php
@@ -1,4 +1,5 @@
 <?php
-class Object{
+class Objet{
+// Objet is not a typo, Object is a reserved keywork in 7.2+
 }
 ?>


### PR DESCRIPTION
Discovered in Fedora QA with 7.2.0RC5
https://apps.fedoraproject.org/koschei/package/php-zetacomponents-base?collection=f28

`PHP Fatal error:  Cannot use 'Object' as class name as it is reserved in /builddir/build/BUILD/Base-f20df24e8de3e48b6b69b2503f917e457281e687/tests/test_repository/object/object.php on line 2`