### PR TITLE
PHP 8.1: fix method signature deprecation warnings

### DIFF
--- a/src/options.php
+++ b/src/options.php
@@ -137,6 +137,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      * @param string $propertyName The name of the option to get.
      * @return bool Whether the option exists.
      */
+    #[ReturnTypeWillChange]
     public function offsetExists( $propertyName )
     {
         return $this->__isset( $propertyName );
@@ -151,6 +152,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      * @param string $propertyName The name of the option to get.
      * @return mixed The option value.
      */
+    #[ReturnTypeWillChange]
     public function offsetGet( $propertyName )
     {
         return $this->__get( $propertyName );
@@ -167,6 +169,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      * @param string $propertyName The name of the option to set.
      * @param mixed $propertyValue The value for the option.
      */
+    #[ReturnTypeWillChange]
     public function offsetSet( $propertyName, $propertyValue )
     {
         $this->__set( $propertyName, $propertyValue );
@@ -182,6 +185,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      *         If a the value for a property is out of range.
      * @param string $propertyName The name of the option to unset.
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset( $propertyName )
     {
         $this->__set( $propertyName, null );
@@ -192,6 +196,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current( $this->properties );
@@ -202,6 +207,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key( $this->properties );
@@ -212,6 +218,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next( $this->properties );
@@ -222,6 +229,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset( $this->properties );
@@ -233,6 +241,7 @@ abstract class ezcBaseOptions implements ArrayAccess, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $key = key( $this->properties );


### PR DESCRIPTION
As of PHP 8.1, PHP will start throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

These are now fixed by using the suggested attribute.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.